### PR TITLE
Update 30_keras_autoencoder.md

### DIFF
--- a/30_keras_autoencoder.md
+++ b/30_keras_autoencoder.md
@@ -81,16 +81,16 @@ from keras.layers import Input, Dense
 from keras.models import Model
 
 # 인코딩될 표현(representation)의 크기
-encoding_dim = 32 # 32 floats -> 24.5의 압축으로 입력이 784 float라고 가정 
+encoding_dim = 32 # 입력이 784 float라고 가정했을 때, 표현될 크기를 32 floats로 하면 -> 24.5의 압축
 
 # 입력 플레이스홀더
 input_img = Input(shape=(784,))
 # "encoded"는 입력의 인코딩된 표현
 encoded = Dense(encdoing_dim, activation='relu')(input_img)
-# "decoded"는 입력의 손실있는 재구성 (lossy reconstruction)
+# "decoded"는 입력의 손실 복원 (lossy reconstruction)
 decoded = Dense(784, activation='sigmoid')(encoded)
 
-# 입력을 입력의 재구성으로 매핑할 모델
+# 입력을 복원된 입력으로 매핑할 모델
 autoencoder = Model(input_img, decoded)
 ```
 


### PR DESCRIPTION
1. 예제 코드에서 '24.5의 압축'이라는 표현이 이해가 어려울 것 같아 풀어서 썼습니다.
2. lossy reconstruction은 (압축/인코딩/디코딩 용어의 개념에서) 손실 '복원' 이라는 표현이 적합할 것 같습니다.
  - 글 전체적으로 바꾸는 건 너무 과할 것 같아서 해당 예제 코드에서만 수정하여 제안합니다.